### PR TITLE
Fix issue with adding random suffix to headers

### DIFF
--- a/vercel_storage/blob.py
+++ b/vercel_storage/blob.py
@@ -28,7 +28,7 @@ def get_token(options: dict):
     return _tkn
 
 
-def dump_headers(options: dict, headers: dict):
+def dump_headers(options: Optional[dict], headers: dict):
     if options.get("debug", False):
         print(tabulate([(k, v) for k, v in headers.items()]))
 

--- a/vercel_storage/blob.py
+++ b/vercel_storage/blob.py
@@ -29,6 +29,8 @@ def get_token(options: dict):
 
 
 def dump_headers(options: Optional[dict], headers: dict):
+    if options is None:
+        options = {}
     if options.get("debug", False):
         print(tabulate([(k, v) for k, v in headers.items()]))
 

--- a/vercel_storage/blob.py
+++ b/vercel_storage/blob.py
@@ -54,7 +54,7 @@ def put(pathname: str, body: bytes, options: Optional[dict] = None) -> dict:
             "cacheControlMaxAge", str(DEFAULT_CACHE_AGE)
         ),
     }
-    if "no_suffix" in options:
+    if options and "no_suffix" in options:
         headers["x-add-random-suffix"] = "false"
 
     dump_headers(options, headers)


### PR DESCRIPTION
This pull request fixes an issue where a random suffix was being added to headers. The issue was caused by a missing check for the "no_suffix" option in the headers. This PR adds the necessary check to ensure that the random suffix is only added when the "no_suffix" option is not present.